### PR TITLE
Update compiler plugin to Java 17

### DIFF
--- a/financial-module-system/finance/egov/pom.xml
+++ b/financial-module-system/finance/egov/pom.xml
@@ -240,7 +240,7 @@
         <mvn.ear.plugin.version>2.10.1</mvn.ear.plugin.version>
         <mvn.war.plugin.version>3.2.0</mvn.war.plugin.version>
         <mvn.jar.plugin.version>3.0.2</mvn.jar.plugin.version>
-        <mvn.compiler.plugin.version>3.7.0</mvn.compiler.plugin.version>
+        <mvn.compiler.plugin.version>3.10.1</mvn.compiler.plugin.version>
         <mvn.dependency.plugin.version>3.0.2</mvn.dependency.plugin.version>
         <mvn.resource.plugin.version>3.0.1</mvn.resource.plugin.version>
         <mvn.versioneye.plugin.version>3.11.4</mvn.versioneye.plugin.version>
@@ -1415,8 +1415,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${mvn.compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- update `mvn.compiler.plugin.version` to `3.10.1`
- compile all finance modules with Java 17

## Testing
- `mvn -f financial-module-system/finance/egov/pom.xml -N validate` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e79f8454832c8eaa8409c420dd9b