### PR TITLE
Update finance module Dockerfile for Java 17

### DIFF
--- a/financial-module-system/finance/Dockerfile
+++ b/financial-module-system/finance/Dockerfile
@@ -1,4 +1,4 @@
-FROM egovio/alpine-maven-builder-jdk-8:gcp AS build
+FROM egovio/alpine-maven-builder-jdk-17 AS build
 ARG WORK_DIR
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN cd ${WORK_DIR} \
 #RUN chmod +x ./${WORK_DIR}/entrypoint.sh && ./${WORK_DIR}/entrypoint.sh
 
 # Create runtime image
-FROM egovio/wildfly:vNA-9371e7becf-6
+FROM egovio/wildfly:jdk17
 
 COPY --from=build /app/egov/egov-ear/target/*.ear /opt/jboss/wildfly/standalone/deployments/
 USER jboss


### PR DESCRIPTION
## Summary
- upgrade finance module build image to `alpine-maven-builder-jdk-17`
- use WildFly base with Java 17 for runtime

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68679a927fe4832c9972da58eb5e5131