### PR TITLE
Add javax.annotation-api dependency

### DIFF
--- a/financial-module-system/finance/egov/pom.xml
+++ b/financial-module-system/finance/egov/pom.xml
@@ -1113,6 +1113,12 @@
         </dependency>
         <!-- SERVLET SPEC JBOSS DEPENDENCIES END -->
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- COMMONS START -->
         <dependency>
             <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
## Summary
- add `javax.annotation-api` dependency for Java 17 compatibility

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679a8e0490832cac3058714108de09